### PR TITLE
feat: add verified users to the Resend segment

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -32,6 +32,7 @@ AGENCY_YEARLY_PRICE_ID=price_
 # ---------------------
 PLUNK_SECRET_KEY=sk_
 RESEND_API_KEY=re_
+RESEND_SEGMENT_ID= 
 
 # ---------------------
 # 

--- a/apps/web/src/app/api/inngest/route.ts
+++ b/apps/web/src/app/api/inngest/route.ts
@@ -1,4 +1,5 @@
 import { inngest } from "@/server/inngest";
+import { addContactToSegment } from "@/server/inngest/add-contact-to-segment";
 import { createGitHubIssue } from "@/server/inngest/create-github-issue";
 import { createJiraIssue } from "@/server/inngest/create-jira-issue";
 import { createLinearIssue } from "@/server/inngest/create-linear-issue";
@@ -37,6 +38,7 @@ export const { GET, POST, PUT } = serve({
     refreshJiraWebhooks,
     refreshJiraInstallationWebhooks,
     sendWelcomeEmail,
+    addContactToSegment,
     notifySlackFeedbackCreated,
     updateSlackFeedbackMessage,
   ],

--- a/apps/web/src/lib/mailer/client.ts
+++ b/apps/web/src/lib/mailer/client.ts
@@ -6,6 +6,7 @@ export const mailer = createMailer();
 
 // Re-export types for convenience
 export type {
+  AddContactToSegmentOptions,
   Contact,
   CreateContactOptions,
   EmailAttachment,

--- a/apps/web/src/lib/mailer/plunk.ts
+++ b/apps/web/src/lib/mailer/plunk.ts
@@ -338,5 +338,15 @@ export class PlunkMailer implements Mailer {
         throw new EmailError(message);
       }
     },
+
+    // Plunk has no segment equivalent: contacts are targeted through triggers
+    // and campaigns instead. Fail loudly rather than silently dropping the call
+    // if the mailer provider is ever switched back to Plunk.
+    addToSegment: async (): Promise<void> => {
+      throw new EmailError(
+        "Plunk does not support segments",
+        "UNSUPPORTED_OPERATION"
+      );
+    },
   };
 }

--- a/apps/web/src/lib/mailer/resend.ts
+++ b/apps/web/src/lib/mailer/resend.ts
@@ -5,6 +5,7 @@ import { Resend } from "resend";
 import { isDevelopment } from "@/utils/environment/env";
 
 import {
+  AddContactToSegmentOptions,
   Contact,
   CreateContactOptions,
   EmailError,
@@ -162,6 +163,28 @@ export class ResendMailer implements Mailer {
       }
 
       return contact;
+    },
+
+    addToSegment: async (options: AddContactToSegmentOptions): Promise<void> => {
+      if (!options.id && !options.email) {
+        throw new EmailError(
+          "Either id or email must be provided",
+          "MISSING_IDENTIFIER"
+        );
+      }
+
+      const identifier = options.id
+        ? ({ contactId: options.id } as const)
+        : ({ email: options.email! } as const);
+
+      const { error } = await this.client.contacts.segments.add({
+        ...identifier,
+        segmentId: options.segmentId,
+      });
+
+      if (error) {
+        throw new EmailError(error.message, error.name);
+      }
     },
   };
 }

--- a/apps/web/src/lib/mailer/types.ts
+++ b/apps/web/src/lib/mailer/types.ts
@@ -51,6 +51,12 @@ export type UpdateContactOptions = {
   data?: Record<string, unknown>;
 };
 
+export type AddContactToSegmentOptions = {
+  id?: string;
+  email?: string;
+  segmentId: string;
+};
+
 export interface Mailer {
   emails: {
     send(options: MailOptions): Promise<EmailResponse>;
@@ -61,5 +67,6 @@ export interface Mailer {
     get(id: string): Promise<Contact>;
     update(options: UpdateContactOptions): Promise<Contact>;
     delete(id: string): Promise<Contact>;
+    addToSegment(options: AddContactToSegmentOptions): Promise<void>;
   };
 }

--- a/apps/web/src/server/inngest/add-contact-to-segment.ts
+++ b/apps/web/src/server/inngest/add-contact-to-segment.ts
@@ -1,0 +1,48 @@
+import { mailer } from "@/lib/mailer/client";
+import { prisma } from "@workspace/db";
+import { inngest } from "./index";
+
+export const addContactToSegment = inngest.createFunction(
+  {
+    id: "add-contact-to-segment",
+    retries: 3,
+    // A re-emit of the same verification must not re-run the provider calls.
+    idempotency: "event.data.userId",
+    // Verified addresses only, so the segment never accumulates unconfirmed
+    // sign-ups. Idempotency is per-function, so this shares the trigger with
+    // send-welcome-email without either suppressing the other.
+    triggers: [{ event: "user/email-verified" }],
+  },
+  async ({ event }) => {
+    const { userId } = event.data as { userId: string };
+
+    // Self-hosted instances have no marketing segment configured.
+    const segmentId = process.env.RESEND_SEGMENT_ID;
+    if (!segmentId) return { skipped: "no_segment_configured" };
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { email: true },
+    });
+
+    if (!user) return { skipped: "user_not_found" };
+
+    const email = user.email.toLowerCase().trim();
+
+    try {
+      await mailer.contacts.create({ email, subscribed: true });
+    } catch (error) {
+      // The contact may already exist (earlier newsletter signup, or a
+      // re-registration after account deletion). The segment add below is the
+      // operation that must succeed, so a failed create is not fatal here.
+      console.warn(
+        `[add-contact-to-segment] contact create failed userId=${userId}`,
+        error,
+      );
+    }
+
+    await mailer.contacts.addToSegment({ email, segmentId });
+
+    return { userId };
+  },
+);

--- a/apps/web/turbo.json
+++ b/apps/web/turbo.json
@@ -23,6 +23,7 @@
 
         "PLUNK_SECRET_KEY",
         "RESEND_API_KEY",
+        "RESEND_SEGMENT_ID",
 
         "STORAGE_REGION",
         "STORAGE_BUCKET_NAME",


### PR DESCRIPTION
## Summary

New users are enrolled in the Resend marketing segment once their email is verified.

- Adds `contacts.addToSegment` to the mailer interface, implemented against Resend's `contacts.segments.add`. Plunk has no segment equivalent, so it throws `UNSUPPORTED_OPERATION` rather than silently no-op'ing if the provider is ever switched back.
- New Inngest function `add-contact-to-segment`, triggered by the existing `user/email-verified` event: creates the contact, then adds it to `RESEND_SEGMENT_ID`.

## Notes

- **Verified addresses only.** The trigger is `user/email-verified` rather than user creation, so the segment never accumulates unconfirmed sign-ups. Idempotency is per-function, so this shares the trigger with `send-welcome-email` without either suppressing the other.
- **A failed `contacts.create` is logged, not fatal** — the contact may already exist from an earlier signup or a re-registration. The segment add is the operation that must succeed.
- **Missing `RESEND_SEGMENT_ID` skips cleanly**, which keeps self-hosted instances working.
- Existing verified users are not backfilled; they never emit a fresh `user/email-verified`.

## Requires

`RESEND_SEGMENT_ID` set in the deployment environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)